### PR TITLE
Added Referece link to the jasmine file for VS Intellisense

### DIFF
--- a/generators/directive/templates/complex/directive-spec.js
+++ b/generators/directive/templates/complex/directive-spec.js
@@ -1,3 +1,4 @@
+///<reference path="../../../.grunt/grunt-contrib-jasmine/jasmine.js"/>
 describe('<%= _.camelize(name) %>', function() {
 
   beforeEach(module('<%= appname %>'));

--- a/generators/directive/templates/simple/directive-spec.js
+++ b/generators/directive/templates/simple/directive-spec.js
@@ -1,3 +1,4 @@
+///<reference path="../../../.grunt/grunt-contrib-jasmine/jasmine.js"/>
 describe('<%= _.camelize(name) %>', function() {
 
   beforeEach(module('<%= appname %>'));

--- a/generators/filter/templates/filter-spec.js
+++ b/generators/filter/templates/filter-spec.js
@@ -1,3 +1,4 @@
+///<reference path="../../../.grunt/grunt-contrib-jasmine/jasmine.js"/>
 describe('<%= _.camelize(name) %>', function() {
 
     beforeEach(module('<%= appname %>'));

--- a/generators/modal/templates/modal-spec.js
+++ b/generators/modal/templates/modal-spec.js
@@ -1,3 +1,4 @@
+///<reference path="../../../.grunt/grunt-contrib-jasmine/jasmine.js"/>
 describe('<%= ctrlname %>', function() {
 
     beforeEach(module('<%= appname %>'));

--- a/generators/service/templates/service-spec.js
+++ b/generators/service/templates/service-spec.js
@@ -1,3 +1,4 @@
+///<reference path="../../../.grunt/grunt-contrib-jasmine/jasmine.js"/>
 describe('<%= _.camelize(name) %>', function() {
 
   beforeEach(module('<%= appname %>'));

--- a/generators/view/templates/view-spec.js
+++ b/generators/view/templates/view-spec.js
@@ -1,3 +1,4 @@
+///<reference path="../../../.grunt/grunt-contrib-jasmine/jasmine.js"/>
 describe('<%= ctrlname %>', function() {
 
     beforeEach(module('<%= appname %>'));


### PR DESCRIPTION
This adds a rerference link at the top of the *-spec.js files so that VS intellisense can help with the jasmine code.